### PR TITLE
Fix panic and cursor display issues for wide characters in the input field

### DIFF
--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -16,3 +16,4 @@ serde = "1.0.188"
 serde_json = "1.0.105"
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-stream = { version = "0.1.14" }
+unicode-width = "0.1"


### PR DESCRIPTION
This PR fixes issues with UTF-8 handling, specifically for wide characters like Korean.

## Fixes
- Prevents panic when inserting UTF-8 characters by properly checking character boundaries.
- Corrects cursor positioning for wide characters using the unicode-width crate.

## How to test
To test this PR, you can copy and paste the following UTF-8 strings into the input field and observe the behavior.

### UTF-8 Strings to test:
- "안녕하세요" (Korean)
- "你好世界" (Chinese)
- "こんにちは世界" (Japanese)
- "😀😁😂🤣" (Emoji)

### Steps:

- Run the program using the previous version and paste any of the above strings into the input field.
- Observe whether the program panics when inserting these characters.
- In the updated version (this PR), ensure that the program no longer panics and that the cursor aligns correctly when wide characters are inserted.
